### PR TITLE
修复推理报错问题&优化命令行界面与功能

### DIFF
--- a/src/control/cmdline.jl
+++ b/src/control/cmdline.jl
@@ -1,31 +1,14 @@
 function ignite(nacore::NaCore)
-    mem = nacore.mem
-    buffer = nacore.internal_exp
-
     while true
-        print("Junars> ")
+        # 输出彩色字符（绿色粗体→"Junars> "→重置格式 ）
+        print("\e[1;32mJunars> \e[0m")
         input = readline(stdin) |> strip |> string
-        length(input) == 0 && continue
-        if input == ":q" || input == ":quit"
-            return
-        elseif input == ":p"
-            @show count(mem)
-            showtracks(mem)
-            continue
-        elseif startswith(input, ":c")
-            if length(input) == 2
-                cycle!(nacore)
-                continue
-            end
-            if input == ":cp"
-                cycle!(nacore)
-                showtracks(mem)
-                continue
-            end
-            for i in 1:parse(Int, input[3:end])
-                cycle!(nacore)
-            end
-            continue
+        isempty(input) && continue
+        # 冒号开头的特殊指令
+        if startswith(input, ':')
+            response = handleColonCmd(nacore, input[2:end])
+            isnothing(response) && return # quit指令
+            response && continue # 若有响应，不作为语句执行
         end
         task = nothing
         try
@@ -35,6 +18,42 @@ function ignite(nacore::NaCore)
             continue
         end
     end
+end
+
+"""
+处理「冒号命令」
+参数「cmdStr」：不带冒号
+返回：命令是否被执行
+"""
+function handleColonCmd(nacore::NaCore, cmdStr::String)
+
+    mem = nacore.mem
+    buffer = nacore.internal_exp
+
+    args = split(cmdStr) # 将命令拆解成参数列表
+
+    if startswith("quit", args[1]) # 指令「quit」：退出
+        return nothing
+    elseif args[1] == "p" # 指令「:p」：打印跟踪
+        @show count(mem)
+        showtracks(mem)
+        return true
+    elseif startswith(args[1], "c") # 指令「:c」「:cp」：cycle 运行指定周期
+        if cmdStr == "c" # 只有c：直接cycle
+            cycle!(nacore)
+            return true
+        end
+        # 若c/cp后面带参数：循环一定次数
+        length(args) > 1 && for _ in 1:parse(Int, args[2])
+            cycle!(nacore)
+        end
+        # cp：打印跟踪
+        if args[1] == "cp" # cp：先cycle，再打印跟踪
+            showtracks(mem)
+        end
+        return true
+    end
+    return false
 end
 
 function addone(nacore, s::AbstractString)

--- a/src/inference/syllogism.jl
+++ b/src/inference/syllogism.jl
@@ -392,7 +392,7 @@ function abdindcom(::Type{T}, P, S, nar::Nar) where T
     if nar.forward
         Threads.@spawn derivetask2(Forward(), term1, :abduction, nar)
         Threads.@spawn derivetask2(Forward(), term2, :inv_abd, nar)
-        derivetask2(Forward(), term3 :comparision, nar)
+        derivetask2(Forward(), term3, :comparision, nar)
     else
         Threads.@spawn derivetask2(Backward(), term1, nar)
         Threads.@spawn derivetask2(Backward(), term3, nar)


### PR DESCRIPTION
Debug：比较推理的报错问题
 - 原因：`syllogism.jl`中，`term3`与`:comparision`之间缺少逗号

以上报错复现方法：
```
Junars> <A --> B>.
Junars> <A --> C>.
Junars> :c 10
```

功能：命令行界面显示交互优化
- 功能分离：将以冒号「:」开头的「特殊命令」独立成单独的函数
- 功能增强：现在「:cp」指令同样支持数字参数，以便在运行指定步数后打印跟踪
- 显示优化：为输入提示符「Junars> 」添加「绿色粗体」格式