### PR TITLE
修复`conversion`、`ptask`的报错问题 + 显示代码优化

### DIFF
--- a/src/Gene.jl
+++ b/src/Gene.jl
@@ -27,7 +27,7 @@ export Budget, Token, ave_ari, ave_geo, ave_priority, above_threshold
 
 export Truth, expect, absexpdiff, t2q, revision, isnegative
 export deduction, induction, abduction, analogy
-export contraposition, negation, resemblance, exemplification, comparision, intersection, difference
+export contraposition, negation, conversion, resemblance, exemplification, comparision, intersection, difference
 export reduceconj, reducedisj, reduceconj_neg, anonymous_analogy, inv_anonymous_ana,
     inv_abd, inv_ded, inv_ind, inv_com, inv_reduceconj, inv_reducedisj,
     inv_reduceconj_neg, inv_ana, inv_difference

--- a/src/control/cmdline.jl
+++ b/src/control/cmdline.jl
@@ -1,7 +1,6 @@
 function ignite(nacore::NaCore)
     while true
-        # 输出彩色字符（绿色粗体→"Junars> "→重置格式 ）
-        print("\e[1;32mJunars> \e[0m")
+        printstyled("Junars>", bold=true, color=:light_green)
         input = readline(stdin) |> strip |> string
         isempty(input) && continue
         # 冒号开头的特殊指令

--- a/src/control/memory.jl
+++ b/src/control/memory.jl
@@ -42,12 +42,12 @@ end
 """
 把Judgment添加到BeliefTable中,同时尝试修正
 """
-function process_judgment(cpt, task, nar)
+function process_judgment(cpt::Concept, task::NaTask, nar)
     judgment = task.sentence
     oldbest = isnothing(cpt.beliefs) ? nothing : first(cpt.beliefs)
     if !isnothing(oldbest)
         if judgment.stamp == oldbest.stamp
-            if eltype(task.ptask.sentence) <: Judgement
+            if !isnothing(task.ptask) && eltype(task.ptask.sentence) <: Judgement # 要查询，先看有没有
                 dec_priority!(task, 0) # 重复的任务
             end
             return


### PR DESCRIPTION
# `conversion`报错问题

- 功能：双向继承 |- 等价
- 问题：无法找到符号`conversion`（转换）
  - 追踪到的实例：`<A --> B>` + `<B --> A>` ⇒ `<A <-> B>`
- 解决方式：溯源`conversion`定义之处Gene模块，在其导出列表中添加export

报错源码：
```
ERROR: LoadError: UndefVarError: `conversion` not defined
Stacktrace:
  [1] matchreverse(j1::Junars.Gene.Inheritance, j2::Junars.Gene.Inheritance, nar::Junars.Admins.Nar)
    @ Junars.Inference [...]\src\inference\syllogism.jl:197
  [2] syllogisim_aa(j1::Junars.Gene.Inheritance, j2::Junars.Gene.Inheritance, figure::Int64, nar::Junars.Admins.Nar)
    @ Junars.Inference [...]\src\inference\syllogism.jl:97
  [3] syllogisim(j1::Junars.Gene.Inheritance, j2::Junars.Gene.Inheritance, nar::Junars.Admins.Nar)
    @ Junars.Inference [...]\src\inference\syllogism.jl:23
  [4] dispatch(taskterm::Junars.Gene.Inheritance, bterm::Junars.Gene.Inheritance, nar::Junars.Admins.Nar)
    @ Junars.Inference [...]\src\inference\ruledispatch.jl:71
  [5] reason(nar::Junars.Admins.Nar)
    @ Junars.Control [...]\src\control\infer.jl:23
  [6] spike!(nar::Junars.Admins.Nar)
    @ Junars.Control [...]\src\control\launch.jl:41
```

# `ptask`报错问题

- 功能：获取任务**父任务**的语句
- 问题：任务可能没有父任务
  - 追踪到的实例：`Answer: <B-->C>. %1.0;0.45%`
- 解决方式：预先判断任务「是否有父任务」

报错源码：
```
ERROR: LoadError: type Nothing has no field sentence
Stacktrace:
 [1] getproperty(x::Nothing, f::Symbol)
   @ Base .\Base.jl:37
 [2] process_judgment(cpt::Junars.Entity.Concept, task::Junars.Entity.NaTask, nar::Junars.Admins.Nar)
   @ Junars.Control [...]\src\control\memory.jl:50
 [3] directprocess(cpt::Junars.Entity.Concept, task::Junars.Entity.NaTask, nar::Junars.Admins.Nar)
   @ Junars.Control [...]\src\control\memory.jl:36
 [4] absorb!(task::Junars.Entity.NaTask, nar::Junars.Admins.Nar)
   @ Junars.Control [...]\src\control\memory.jl:24
 [5] absorb!(nar::Junars.Admins.Nar)
   @ Junars.Control [...]\src\control\memory.jl:8
```

# 显示代码`cmdline.jl`优化

将原本使用「ANSI转义字符」的输出换成**更Julian**的内置库函数`printstyled`