### PR TITLE
修复两个导致OpenJunars报错的fatal bug

### DIFF
--- a/src/Gene.jl
+++ b/src/Gene.jl
@@ -12,6 +12,7 @@ export ExtSet, IntSet, ExtIntersection, IntIntersection, ExtDiff, IntDiff
 export Product, ExtImage, IntImage, Image
 export Inheritance, Similarity, Implication, Equivalence, Negation, Conjunction, Disjunction
 export Atom, Word, Variable, Action
+export PlaceHolder
 export FOTerm, NALSet, NALIntersection, NALDifference
 
 export ⋃, ⋂, ⊖, ∧, ∨

--- a/src/gene/narsese/nsepretty.jl
+++ b/src/gene/narsese/nsepretty.jl
@@ -21,7 +21,7 @@ name(t::ExtImage) = "(/," * join(name.(t.comps), ",") * ")"
 name(t::IntImage) = "(\\," * join(name.(t.comps), ",") * ")"
 name(t::Product) = "(*," * join(name.(t.comps), ",") * ")"
 
-name(t::Negation) = "(¬,$(name(t.ϕ)))"
+name(t::Negation) = "(¬,$(name(t.comps[1])))"
 name(t::Conjunction) = "(&&," * join(name.(t.comps), ",") * ")"
 name(t::Disjunction) = "(||," * join(name.(t.comps), ",") * ")"
 


### PR DESCRIPTION
用自己的Narsese库[JuNarsese](https://github.com/ARCJ137442/JuNarsese.jl)做对比测试时，顺带修复的两个OpenJunars的bug：
1. 「陈述否定」因「调用不存在属性」无法显示
2. 外部调用OpenJunars时，因「像占位符PlaceHolder未导出」导致「无法正常解析外延像/内涵像」